### PR TITLE
Account number validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,23 @@ Formats a Norwegian 11-digit bank account number on the standard form (4, 2, 5 d
 
 ## Examples
 
-    import { formatAccountNumber } from 'norwegian-utils/formatAccountNumber'
+    import formatAccountNumber from 'norwegian-utils/formatAccountNumber'
     formatAccountNumber('36242412345') === '3624 24 12345'
     formatAccountNumber('362424123451') === '3624 241 23451'
+
+# validateAccountNumber
+
+Validates norwegian account number to have 11 digits and checking the last control digit according to MOD11 algorithm.
+Accepts strings with spaces and dots, those are stripped before validation.
+Returns true if the number satisfies the constraints and false otherwise.
+
+## Examples
+
+    import validateAccountNumber from 'norwegian-utils/validateAccountNumber'
+    validateAccountNumber('1234.56.78903') //true
+    validateAccountNumber('1234.56.78909') //false
+    validateAccountNumber('1234 56 78903') //true
+    validateAccountNumber('123437q897e9w87qw89e75678903') //false
 
 # formatAmount
 

--- a/formatAccountNumber/formatAccountNumber.test.ts
+++ b/formatAccountNumber/formatAccountNumber.test.ts
@@ -10,8 +10,16 @@ describe('test formatting account numbers', () => {
   })
 
   it('should try for invalid numbers', () => {
-    expect(formatAccountNumber('362.424.123.123.45')).toBe('3624\u00a024123\u00a012345')
-    expect(formatAccountNumber('362.424.45')).toBe('36242445')
-    expect(formatAccountNumber('362.424.455')).toBe('362424455')
+    expect(formatAccountNumber('362.424.123.123.45')).toBe('3624\u00a024\u00a012312')
+    expect(formatAccountNumber('362.424.45')).toBe('3624\u00a024\u00a045')
+    expect(formatAccountNumber('362.424.455')).toBe('3624\u00a024\u00a0455')
+    expect(formatAccountNumber('12')).toBe('12')
+    expect(formatAccountNumber('')).toBe('')
+    expect(formatAccountNumber('hello')).toBe('hell\u00a0o')
+    expect(formatAccountNumber('*******1234')).toBe('****\u00a0**\u00a0*1234')
+  })
+
+  it('should format masked number', () => {
+    expect(formatAccountNumber('*******1234')).toBe('****\u00a0**\u00a0*1234')
   })
 })

--- a/formatAccountNumber/index.ts
+++ b/formatAccountNumber/index.ts
@@ -1,17 +1,21 @@
-export default (accountNumber: string): string => {
+const ACCOUNT_CHUNKS = [4, 2, 5]
+
+export default (accountNumber: string) => {
   if (!accountNumber) return ''
 
-  // Remove all non-numbers
-  const split = accountNumber.match(/\+?\d*/g)?.join('')
-  if (!split) return accountNumber
+  accountNumber = accountNumber.replace(/[\s.]+/g, '')
+  let result = ''
+  let part
+  let rest
 
-  // First 3 numbers, then X numbers, then 5 numbers
-  const matches = split.match(/(\d{4})(\d*)(\d{5})/)
-  if (matches && matches.length > 0) {
-    if (matches[2]) {
-      return matches.slice(1).join('\u00a0')
+  ACCOUNT_CHUNKS.forEach((length, index) => {
+    if (accountNumber.length) {
+      part = accountNumber.slice(0, length)
+      rest = accountNumber.slice(length)
+      result += part
+      accountNumber = rest
+      if (index < 2) result += '\u00a0'
     }
-  }
-
-  return split
+  })
+  return result.trim()
 }

--- a/formatPhoneNumber/index.ts
+++ b/formatPhoneNumber/index.ts
@@ -55,7 +55,7 @@ const splitIntoGroups = (str: string): string => {
 const norwegianRegex = (phoneNumber: string): { localPart: string } | false => {
   phoneNumber = (phoneNumber + '').replace(/^\+/g, '00').replace(/\D/g, '')
 
-  // avoid matching 8-d;igits numbers like 00123456 or +123456
+  // avoid matching 8-digits numbers like 00123456 or +123456
   if (phoneNumber.match(/^00/) && !phoneNumber.match(/^0047/)) {
     return false
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "styrerommet-utils",
+  "name": "norwegian-utils",
   "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
@@ -509,9 +509,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         }
       }
@@ -988,13 +988,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -1585,7 +1578,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1606,12 +1600,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1626,17 +1622,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1753,7 +1752,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1765,6 +1765,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1779,6 +1780,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1786,12 +1788,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1810,6 +1814,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1890,7 +1895,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1902,6 +1908,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1987,7 +1994,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2023,6 +2031,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2042,6 +2051,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2085,12 +2095,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2161,18 +2173,6 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
-    },
-    "handlebars": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
-      "integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
-      "dev": true,
-      "requires": {
-        "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
-      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -2257,6 +2257,12 @@
       "requires": {
         "whatwg-encoding": "^1.0.1"
       }
+    },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
@@ -2606,12 +2612,12 @@
       }
     },
     "istanbul-reports": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+      "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.1.2"
+        "html-escaper": "^2.0.0"
       }
     },
     "jest": {
@@ -3138,9 +3144,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "kleur": {
@@ -3194,9 +3200,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash.memoize": {
@@ -3320,9 +3326,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mixin-deep": {
@@ -3347,20 +3353,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
+        "minimist": "^1.2.5"
       }
     },
     "ms": {
@@ -3399,12 +3397,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
     "nice-try": {
@@ -3558,24 +3550,6 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        }
       }
     },
     "optionator": {
@@ -4598,17 +4572,6 @@
       "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
       "dev": true
     },
-    "uglify-js": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.3.tgz",
-      "integrity": "sha512-KfQUgOqTkLp2aZxrMbCuKCDGW9slFYu2A23A36Gs7sGzTLcRBDORdOi5E21KWHFIfkY8kzgi/Pr1cXCh0yIp5g==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "commander": "~2.20.3",
-        "source-map": "~0.6.1"
-      }
-    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -4784,12 +4747,6 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "dev": true
-    },
     "wrap-ansi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
@@ -4858,9 +4815,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/validateAccountNumber/index.ts
+++ b/validateAccountNumber/index.ts
@@ -1,0 +1,17 @@
+export default (accountNumber: string) => {
+  /* https://no.wikipedia.org/wiki/MOD11 */
+  const weights = [5, 4, 3, 2, 7, 6, 5, 4, 3, 2]
+  const accountNumberWithoutSpacesAndPeriods = accountNumber.replace(/[\s.]+/g, '')
+  if (accountNumberWithoutSpacesAndPeriods.length !== 11) {
+    return false
+  } else {
+    const controlDigit = parseInt(accountNumberWithoutSpacesAndPeriods.charAt(10), 10)
+    const accountNumberWithoutControlDigit = accountNumberWithoutSpacesAndPeriods.substring(0, 10)
+    let sum = 0
+    for (let index = 0; index < 10; index++) {
+      sum += parseInt(accountNumberWithoutControlDigit.charAt(index), 10) * weights[index]
+    }
+    const reminder = sum % 11
+    return controlDigit === (reminder === 0 ? 0 : 11 - reminder)
+  }
+}

--- a/validateAccountNumber/validateAccountNumber.test.ts
+++ b/validateAccountNumber/validateAccountNumber.test.ts
@@ -1,0 +1,31 @@
+import validateAccountNumber from '.'
+
+describe('Account number validation', () => {
+  it('Should return true for correct account numbers regardless of formatting', () => {
+    expect(validateAccountNumber('1234.56.78903')).toBeTruthy()
+    expect(validateAccountNumber('12345678903')).toBeTruthy()
+    expect(validateAccountNumber('1234 56 78903')).toBeTruthy()
+  })
+
+  it('Should return false for account numbers with wrong control number', () => {
+    expect(validateAccountNumber('1224.56.78903')).toBeFalsy()
+    expect(validateAccountNumber('1234.56.78909')).toBeFalsy()
+    expect(validateAccountNumber('12245678903')).toBeFalsy()
+    expect(validateAccountNumber('12345678909')).toBeFalsy()
+    expect(validateAccountNumber('1224 56 78903')).toBeFalsy()
+    expect(validateAccountNumber('1234 56 78909')).toBeFalsy()
+  })
+
+  it('Should return false for account numbers with incorrect length', () => {
+    expect(validateAccountNumber('1224')).toBeFalsy()
+    expect(validateAccountNumber('12342190109812092180128')).toBeFalsy()
+    expect(validateAccountNumber('0')).toBeFalsy()
+  })
+
+  it('Should return false for account numbers with letters and charachters other than spaces and periods', () => {
+    expect(validateAccountNumber('1224aaa')).toBeFalsy()
+    expect(validateAccountNumber('123456hello')).toBeFalsy()
+    expect(validateAccountNumber('Kontonummer')).toBeFalsy()
+    expect(validateAccountNumber('1224-56-78903')).toBeFalsy()
+  })
+})

--- a/validateAccountNumber/validateAccountNumber.test.ts
+++ b/validateAccountNumber/validateAccountNumber.test.ts
@@ -5,6 +5,7 @@ describe('Account number validation', () => {
     expect(validateAccountNumber('1234.56.78903')).toBeTruthy()
     expect(validateAccountNumber('12345678903')).toBeTruthy()
     expect(validateAccountNumber('1234 56 78903')).toBeTruthy()
+    expect(validateAccountNumber('1234\u00a056\u00a078903')).toBeTruthy()
   })
 
   it('Should return false for account numbers with wrong control number', () => {
@@ -22,7 +23,7 @@ describe('Account number validation', () => {
     expect(validateAccountNumber('0')).toBeFalsy()
   })
 
-  it('Should return false for account numbers with letters and charachters other than spaces and periods', () => {
+  it('Should return false for account numbers with letters and characters other than spaces and periods', () => {
     expect(validateAccountNumber('1224aaa')).toBeFalsy()
     expect(validateAccountNumber('123456hello')).toBeFalsy()
     expect(validateAccountNumber('Kontonummer')).toBeFalsy()


### PR DESCRIPTION
I added a validator and also modified a number formatter a bit (needed support for formatting of masked account number and also formatting on the fly  - while users type)

Tested that it works in styrerommet, but the behaviour has changed slightly - now it doesnt allow numbers longer than 11 digits. Or, it splits them in chunks of 4, 2 and 5 and then cuts the rest :)

Open for discussion here :) But I think it works good for cases I tested, you can also check unit tests.

