### PR TITLE
Swedish locale

### DIFF
--- a/formatAmount/index.ts
+++ b/formatAmount/index.ts
@@ -4,7 +4,12 @@ export default (amount: number, options: { decimals?: boolean; alwaysNegative?: 
     amount = -Math.abs(amount)
   }
 
-  return amount.toLocaleString('nb-NO', {
+  /*17.08.21: Bug in chrome making norwegian locale not available. 
+  Adding polyfills broke login, so let's temporarily (tm) use swedish locale here, which is not broken.
+  https://gitmemory.com/issue/formatjs/formatjs/3066/888110768
+  */
+
+  return amount.toLocaleString('sv-SE', {
     minimumFractionDigits: fractionDigits,
     maximumFractionDigits: fractionDigits,
   })

--- a/formatAmount/index.ts
+++ b/formatAmount/index.ts
@@ -1,3 +1,6 @@
+const hasNorwegian =
+  Intl && Intl.NumberFormat && Intl.NumberFormat.supportedLocalesOf && Intl.NumberFormat.supportedLocalesOf(['nb-NO']).indexOf('nb-NO') !== -1
+
 export default (amount: number, options: { decimals?: boolean; alwaysNegative?: boolean } = {}) => {
   const fractionDigits = options.decimals === undefined || options.decimals === true ? 2 : 0
   if (options.alwaysNegative === true && Math.round(amount) !== 0) {
@@ -9,7 +12,9 @@ export default (amount: number, options: { decimals?: boolean; alwaysNegative?: 
   https://gitmemory.com/issue/formatjs/formatjs/3066/888110768
   */
 
-  return amount.toLocaleString('sv-SE', {
+  const localeString = hasNorwegian ? 'nb-NO' : 'sv-SE'
+
+  return amount.toLocaleString(localeString, {
     minimumFractionDigits: fractionDigits,
     maximumFractionDigits: fractionDigits,
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "norwegian-utils",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "norwegian-utils",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "norwegian-utils",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Utilities used in our Norwegian applications.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "norwegian-utils",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Utilities used in our Norwegian applications.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5970567/129720994-b3681fce-0fc1-432c-9539-733adfddb4db.png)

Long story short - norwegian locale is broken in the newest chrome release, and the force-polyfill that fixes it, breaks everything else in safari. So we came up with an idea to use swedish instead of norwegian here.

